### PR TITLE
Azure TableStorage integration

### DIFF
--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
     <PackageReference Include="Halforbit.Facets" Version="1.0.37" />
     <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.6.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />

--- a/DocumentStores/PostgresMarten/Halforbit.DataStores.DocumentStores.PostgresMarten.Tests/Halforbit.DataStores.DocumentStores.PostgresMarten.Tests.csproj
+++ b/DocumentStores/PostgresMarten/Halforbit.DataStores.DocumentStores.PostgresMarten.Tests/Halforbit.DataStores.DocumentStores.PostgresMarten.Tests.csproj
@@ -15,7 +15,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.3.0" />

--- a/FileStores/AmazonS3/Halforbit.DataStores.FileStores.AmazonS3.Tests/Halforbit.DataStores.FileStores.AmazonS3.Tests.csproj
+++ b/FileStores/AmazonS3/Halforbit.DataStores.FileStores.AmazonS3.Tests/Halforbit.DataStores.FileStores.AmazonS3.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
     <PackageReference Include="Halforbit.Facets" Version="1.0.37" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />

--- a/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.Tests/Halforbit.DataStores.FileStores.BlobStorage.Tests.csproj
+++ b/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.Tests/Halforbit.DataStores.FileStores.BlobStorage.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
     <PackageReference Include="Halforbit.Facets" Version="1.0.37" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />

--- a/FileStores/GoogleDrive/Halforbit.DataStores.FileStores.GoogleDrive.Tests/Halforbit.DataStores.FileStores.GoogleDrive.Tests.csproj
+++ b/FileStores/GoogleDrive/Halforbit.DataStores.FileStores.GoogleDrive.Tests/Halforbit.DataStores.FileStores.GoogleDrive.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
     <PackageReference Include="Halforbit.Facets" Version="1.0.37" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />

--- a/Halforbit.DataStores.TestUtils/Halforbit.DataStores.TestUtils.csproj
+++ b/Halforbit.DataStores.TestUtils/Halforbit.DataStores.TestUtils.csproj
@@ -1,11 +1,11 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
+    <PackageReference Include="CompareNETObjects" Version="4.57.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Halforbit.DataStores" Version="1.3.7" />
     <PackageReference Include="xunit" Version="2.3.0" />

--- a/Halforbit.DataStores.Tests/Halforbit.DataStores.Tests.csproj
+++ b/Halforbit.DataStores.Tests/Halforbit.DataStores.Tests.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="3.9.0" />
     <PackageReference Include="Halforbit.DataStores" Version="1.3.7" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170425-07" />

--- a/Halforbit.DataStores.sln
+++ b/Halforbit.DataStores.sln
@@ -72,6 +72,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halforbit.DataStores.TestUt
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halforbit.DataStores.FtpFileStore.Tests", "Halforbit.DataStores.FtpFileStore.Tests\Halforbit.DataStores.FtpFileStore.Tests.csproj", "{A17CBF76-CC36-4AAD-B2A0-5BFC45FC4E8A}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TableStores", "TableStores", "{0C62F645-E697-440C-9854-3F78F9C23FBF}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AzureTables", "AzureTables", "{335FA862-5B2E-4A94-AB96-C0A157CC88D9}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halforbit.DataStores.TableStores.AzureTables", "TableStores\AzureTables\Halforbit.DataStores.TableStores.AzureTables\Halforbit.DataStores.TableStores.AzureTables.csproj", "{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halforbit.DataStores.TableStores.AzureTables.Tests", "TableStores\AzureTables\Halforbit.DataStores.TableStores.AzureTables.Tests\Halforbit.DataStores.TableStores.AzureTables.Tests.csproj", "{754932E3-CD98-46AF-9911-E06C25669634}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -146,6 +154,14 @@ Global
 		{A17CBF76-CC36-4AAD-B2A0-5BFC45FC4E8A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A17CBF76-CC36-4AAD-B2A0-5BFC45FC4E8A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A17CBF76-CC36-4AAD-B2A0-5BFC45FC4E8A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}.Release|Any CPU.Build.0 = Release|Any CPU
+		{754932E3-CD98-46AF-9911-E06C25669634}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{754932E3-CD98-46AF-9911-E06C25669634}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{754932E3-CD98-46AF-9911-E06C25669634}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{754932E3-CD98-46AF-9911-E06C25669634}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -174,6 +190,9 @@ Global
 		{F06FFA34-624D-44C3-B2A2-DE6E36B14234} = {B4129E3B-0288-47D0-8EDA-65774D23BA81}
 		{B9791E35-00B8-463A-8655-D1B91A7F9635} = {F06FFA34-624D-44C3-B2A2-DE6E36B14234}
 		{DF6906BD-42FB-45C6-94BD-A587EF3A6DDB} = {F06FFA34-624D-44C3-B2A2-DE6E36B14234}
+		{335FA862-5B2E-4A94-AB96-C0A157CC88D9} = {0C62F645-E697-440C-9854-3F78F9C23FBF}
+		{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40} = {335FA862-5B2E-4A94-AB96-C0A157CC88D9}
+		{754932E3-CD98-46AF-9911-E06C25669634} = {335FA862-5B2E-4A94-AB96-C0A157CC88D9}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A5BC1191-5358-4BC2-8427-D1482D49ED83}

--- a/Halforbit.DataStores.sln
+++ b/Halforbit.DataStores.sln
@@ -70,15 +70,15 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halforbit.DataStores.Docume
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halforbit.DataStores.TestUtils", "Halforbit.DataStores.TestUtils\Halforbit.DataStores.TestUtils.csproj", "{488FAC29-FF2D-4CB1-B6F0-DAF8317727C6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halforbit.DataStores.FtpFileStore.Tests", "Halforbit.DataStores.FtpFileStore.Tests\Halforbit.DataStores.FtpFileStore.Tests.csproj", "{A17CBF76-CC36-4AAD-B2A0-5BFC45FC4E8A}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halforbit.DataStores.FtpFileStore.Tests", "Halforbit.DataStores.FtpFileStore.Tests\Halforbit.DataStores.FtpFileStore.Tests.csproj", "{A17CBF76-CC36-4AAD-B2A0-5BFC45FC4E8A}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TableStores", "TableStores", "{0C62F645-E697-440C-9854-3F78F9C23FBF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "AzureTables", "AzureTables", "{335FA862-5B2E-4A94-AB96-C0A157CC88D9}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halforbit.DataStores.TableStores.AzureTables", "TableStores\AzureTables\Halforbit.DataStores.TableStores.AzureTables\Halforbit.DataStores.TableStores.AzureTables.csproj", "{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halforbit.DataStores.TableStores.AzureTables", "TableStores\AzureTables\Halforbit.DataStores.TableStores.AzureTables\Halforbit.DataStores.TableStores.AzureTables.csproj", "{8C6F9F55-CEFA-4356-8A1E-7493BF63BA40}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Halforbit.DataStores.TableStores.AzureTables.Tests", "TableStores\AzureTables\Halforbit.DataStores.TableStores.AzureTables.Tests\Halforbit.DataStores.TableStores.AzureTables.Tests.csproj", "{754932E3-CD98-46AF-9911-E06C25669634}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Halforbit.DataStores.TableStores.AzureTables.Tests", "TableStores\AzureTables\Halforbit.DataStores.TableStores.AzureTables.Tests\Halforbit.DataStores.TableStores.AzureTables.Tests.csproj", "{754932E3-CD98-46AF-9911-E06C25669634}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/AzureTablesDataStoreTests.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/AzureTablesDataStoreTests.cs
@@ -1,0 +1,71 @@
+﻿using Halforbit.DataStores.Interface;
+using Halforbit.DataStores.TableStores.AzureTables.Implementation;
+using Halforbit.DataStores.Tests;
+using Halforbit.ObjectTools.Extensions;
+using System;
+using System.Linq;
+using Xunit;
+
+namespace Halforbit.DataStores.TableStores.AzureTables.Tests
+{
+    public class AzureTablesDataStoreTests : UniversalIntegrationTest
+    {
+        protected override string ConfigPrefix => "Halforbit.DataStores.TableStores.AzureTables.Tests.";
+
+        [Fact, Trait("Type", "Integration")]
+        public void TestAzureTables()
+        {
+            var testKey = new LocalTestValue.Key(accountId: Guid.NewGuid());
+
+            var testValueA = new LocalTestValue(
+                accountId: testKey.AccountId.Value,
+                message: "Hello, world!");
+
+            var testValueB = new LocalTestValue(
+                accountId: testKey.AccountId.Value,
+                message: "Kthx, world!");
+
+            var dataStore = new AzureTableStore<LocalTestValue.Key, LocalTestValue>(
+                connectionString: GetConfig("ConnectionString"),
+                tableName: GetConfig("TableName"),
+                keyMap: "test-values_{AccountId}");
+
+            ClearDataStore(dataStore);
+
+            TestDataStore(
+                dataStore,
+                testKey,
+                testValueA,
+                testValueB);
+        }
+    }
+
+    public class LocalTestValue
+    {
+        public LocalTestValue() {
+
+        }
+        public LocalTestValue(
+            Guid accountId = default(Guid),
+            string message = default(string))
+        {
+            AccountId = accountId.OrNewGuidIfDefault();
+
+            Message = message;
+        }
+
+        public Guid AccountId { get; private set; }
+
+        public string Message { get; private set; }
+
+        public class Key : UniversalIntegrationTest.ITestKey
+        {
+            public Key(Guid? accountId)
+            {
+                AccountId = accountId;
+            }
+
+            public Guid? AccountId { get; }
+        }
+    }
+}

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/AzureTablesDataStoreTests.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/AzureTablesDataStoreTests.cs
@@ -15,20 +15,24 @@ namespace Halforbit.DataStores.TableStores.AzureTables.Tests
         [Fact, Trait("Type", "Integration")]
         public void TestAzureTables()
         {
-            var testKey = new LocalTestValue.Key(accountId: Guid.NewGuid());
+            var testKey = new AzureTablesTestValue.Key(
+                accountId: Guid.NewGuid(),
+                secondaryId: Guid.NewGuid());
 
-            var testValueA = new LocalTestValue(
+            var testValueA = new AzureTablesTestValue(
                 accountId: testKey.AccountId.Value,
+                secondaryId: testKey.SecondaryId.Value,
                 message: "Hello, world!");
 
-            var testValueB = new LocalTestValue(
+            var testValueB = new AzureTablesTestValue(
                 accountId: testKey.AccountId.Value,
+                secondaryId: testKey.SecondaryId.Value,
                 message: "Kthx, world!");
 
-            var dataStore = new AzureTableStore<LocalTestValue.Key, LocalTestValue>(
+            var dataStore = new AzureTableStore<AzureTablesTestValue.Key, AzureTablesTestValue>(
                 connectionString: GetConfig("ConnectionString"),
                 tableName: GetConfig("TableName"),
-                keyMap: "test-values_{AccountId}");
+                keyMap: "test-values_{AccountId}|{SecondaryId}");
 
             ClearDataStore(dataStore);
 
@@ -38,34 +42,122 @@ namespace Halforbit.DataStores.TableStores.AzureTables.Tests
                 testValueA,
                 testValueB);
         }
+
+        [Fact, Trait("Type", "Integration")]
+        public void TestPartialPartitionKey() 
+        {
+            var testKeyA = new AzureTablesTestValue.Key(
+                accountId: Guid.NewGuid(),
+                secondaryId: Guid.NewGuid());
+
+            var testKeyB = new AzureTablesTestValue.Key(
+                accountId: Guid.NewGuid(),
+                secondaryId: Guid.NewGuid());
+
+            var testKeyC = new AzureTablesTestValue.Key(
+                accountId: testKeyB.AccountId,
+                secondaryId: Guid.NewGuid());
+
+            var testValueA = new AzureTablesTestValue(
+                accountId: testKeyA.AccountId.Value,
+                secondaryId: testKeyA.SecondaryId.Value,
+                message: "Hello, world!");
+
+            var testValueB = new AzureTablesTestValue(
+                accountId: testKeyB.AccountId.Value,
+                secondaryId: testKeyB.SecondaryId.Value,
+                message: "Kthx, world!");
+
+            var testValueC = new AzureTablesTestValue(
+                accountId: testKeyC.AccountId.Value,
+                secondaryId: testKeyC.SecondaryId.Value,
+                message: "¡Hola, mundo!");
+
+            var dataStore = new AzureTableStore<AzureTablesTestValue.Key, AzureTablesTestValue>(
+                connectionString: GetConfig("ConnectionString"),
+                tableName: GetConfig("TableName"),
+                keyMap: "test-values_{AccountId}_key-map-test|{SecondaryId}");
+
+            ClearDataStore(dataStore);
+
+            var preResult = dataStore.ListValues().Result;
+
+            var createAResult = dataStore.Create(testKeyA, testValueA).Result;
+
+            var createBResult = dataStore.Create(testKeyB, testValueB).Result;
+
+            var createCResult = dataStore.Create(testKeyC, testValueC).Result;
+
+            var listAllResult = dataStore.ListValues().Result;
+
+            Assert.True(listAllResult.Count() == 3);
+
+            var listAResult = dataStore.ListValues(k => k.AccountId == testKeyA.AccountId).Result;
+
+            Assert.True(listAResult.SingleOrDefault()?.AccountId == testKeyA.AccountId);
+
+            var listBCResult = dataStore.ListValues(k => k.AccountId == testKeyB.AccountId).Result.ToList();
+
+            Assert.True(
+                listBCResult.Count == 2 
+                && listBCResult.Select(r => r.AccountId).Distinct().SingleOrDefault() == testKeyB.AccountId);
+
+            var listBSpecificResult = dataStore
+                .ListValues(k => k.AccountId == testKeyB.AccountId && k.SecondaryId == testKeyB.SecondaryId)
+                .Result;
+        
+            Assert.True(listBSpecificResult.SingleOrDefault()?.SecondaryId == testKeyB.SecondaryId);
+
+            var deleteAResult = dataStore.Delete(testKeyA).Result;
+
+            var deleteBResult = dataStore.Delete(testKeyB).Result;
+
+            var deleteCResult = dataStore.Delete(testKeyC).Result;
+
+            var postListResult = dataStore.ListKeyValues().Result;
+
+            Assert.True(postListResult.Count() == 0);
+        }
     }
 
-    public class LocalTestValue
+    public class AzureTablesTestValue
     {
-        public LocalTestValue() {
+        public AzureTablesTestValue() {
 
         }
-        public LocalTestValue(
+
+        public AzureTablesTestValue(
             Guid accountId = default(Guid),
+            Guid secondaryId = default(Guid),
             string message = default(string))
         {
             AccountId = accountId.OrNewGuidIfDefault();
+
+            SecondaryId = secondaryId.OrNewGuidIfDefault();
 
             Message = message;
         }
 
         public Guid AccountId { get; private set; }
 
+        public Guid SecondaryId { get; private set; }
+
         public string Message { get; private set; }
 
         public class Key : UniversalIntegrationTest.ITestKey
         {
-            public Key(Guid? accountId)
+            public Key(
+                Guid? accountId,
+                Guid? secondaryId)
             {
                 AccountId = accountId;
+
+                SecondaryId = secondaryId;
             }
 
             public Guid? AccountId { get; }
+
+            public Guid? SecondaryId { get; }
         }
     }
 }

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/AzureTablesDataStoreTests.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/AzureTablesDataStoreTests.cs
@@ -1,5 +1,4 @@
-﻿using Halforbit.DataStores.Interface;
-using Halforbit.DataStores.TableStores.AzureTables.Implementation;
+﻿using Halforbit.DataStores.TableStores.AzureTables.Implementation;
 using Halforbit.DataStores.Tests;
 using Halforbit.ObjectTools.Extensions;
 using System;

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/Halforbit.DataStores.TableStores.AzureTables.Tests.csproj
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/Halforbit.DataStores.TableStores.AzureTables.Tests.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\Halforbit.DataStores.TestUtils\Halforbit.DataStores.TestUtils.csproj" />
+    <ProjectReference Include="..\Halforbit.DataStores.TableStores.AzureTables\Halforbit.DataStores.TableStores.AzureTables.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <UserSecretsId>Halforbit.DataStores</UserSecretsId>
+  </PropertyGroup>
+
+</Project>

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/Halforbit.DataStores.TableStores.AzureTables.Tests.csproj
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/Halforbit.DataStores.TableStores.AzureTables.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Exceptions/InvalidAzureTableKeyMapException.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Exceptions/InvalidAzureTableKeyMapException.cs
@@ -1,0 +1,10 @@
+using System;
+
+namespace Halforbit.DataStores.TableStores.AzureTables.Exceptions 
+{
+    public class InvalidAzureTableKeyMapException : Exception 
+    {
+        public InvalidAzureTableKeyMapException(string message) 
+            : base(message) { }
+    }
+}

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Facets/ConnectionStringAttribute.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Facets/ConnectionStringAttribute.cs
@@ -1,0 +1,15 @@
+﻿using Halforbit.DataStores.TableStores.AzureTables.Implementation;
+using Halforbit.Facets.Attributes;
+using System;
+
+namespace Halforbit.DataStores.TableStores.AzureTables.Facets
+{
+    public class ConnectionStringAttribute : FacetParameterAttribute
+    {
+        public ConnectionStringAttribute(string value = null, string configKey = null) : base(value, configKey) { }
+
+        public override Type TargetType => typeof(AzureTableStore<,>);
+
+        public override string ParameterName => "connectionString";
+    }
+}

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Facets/TableNameAttribute.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Facets/TableNameAttribute.cs
@@ -1,0 +1,15 @@
+﻿using Halforbit.DataStores.TableStores.AzureTables.Implementation;
+using Halforbit.Facets.Attributes;
+using System;
+
+namespace Halforbit.DataStores.TableStores.AzureTables.Facets
+{
+    public class TableNameAttribute : FacetParameterAttribute
+    {
+        public TableNameAttribute(string value = null, string configKey = null) : base(value, configKey) { }
+
+        public override Type TargetType => typeof(AzureTableStore<,>);
+
+        public override string ParameterName => "tableName";
+   } 
+}

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Halforbit.DataStores.TableStores.AzureTables.csproj
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Halforbit.DataStores.TableStores.AzureTables.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Halforbit.DataStores" Version="1.3.4" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="0.10.0-preview" />
+  </ItemGroup>
+
+</Project>

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Implementation/AzureTableStore.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Implementation/AzureTableStore.cs
@@ -1,21 +1,21 @@
-﻿using System;
+﻿using Halforbit.DataStores.FileStores.Exceptions;
+using Halforbit.DataStores.Interface;
+using Halforbit.DataStores.TableStores.AzureTables.Exceptions;
+using Halforbit.DataStores.Validation.Exceptions;
+using Halforbit.DataStores.Validation.Interface;
+using Halforbit.Facets.Attributes;
+using Halforbit.ObjectTools.Collections;
+using Halforbit.ObjectTools.InvariantExtraction.Implementation;
+using Halforbit.ObjectTools.ObjectStringMap.Implementation;
+using Halforbit.ObjectTools.ObjectStringMap.Interface;
+using Microsoft.Azure.Cosmos.Table;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
-using System.Threading.Tasks;
 using System.Net;
-using Halforbit.DataStores.Interface;
-using Halforbit.ObjectTools.ObjectStringMap.Implementation;
-using Halforbit.DataStores.Validation.Interface;
-using Halforbit.Facets.Attributes;
-using Halforbit.ObjectTools.ObjectStringMap.Interface;
-using Microsoft.Azure.Cosmos.Table;
-using Halforbit.ObjectTools.Collections;
-using Halforbit.ObjectTools.InvariantExtraction.Implementation;
-using Halforbit.DataStores.FileStores.Exceptions;
-using Halforbit.DataStores.Validation.Exceptions;
 using System.Text.RegularExpressions;
-using Halforbit.DataStores.TableStores.AzureTables.Exceptions;
+using System.Threading.Tasks;
 
 namespace Halforbit.DataStores.TableStores.AzureTables.Implementation
 {

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Implementation/AzureTableStore.cs
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Implementation/AzureTableStore.cs
@@ -1,0 +1,336 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Threading.Tasks;
+using System.Net;
+using Halforbit.DataStores.Interface;
+using Halforbit.ObjectTools.ObjectStringMap.Implementation;
+using Halforbit.DataStores.Validation.Interface;
+using Halforbit.Facets.Attributes;
+using Halforbit.ObjectTools.ObjectStringMap.Interface;
+using Microsoft.Azure.Cosmos.Table;
+using Halforbit.ObjectTools.Collections;
+using Halforbit.ObjectTools.InvariantExtraction.Implementation;
+using Halforbit.DataStores.FileStores.Exceptions;
+using Halforbit.DataStores.Validation.Exceptions;
+
+namespace Halforbit.DataStores.TableStores.AzureTables.Implementation
+{
+    public class AzureTableStore<TKey, TValue> :
+        IDataStore<TKey, TValue>
+    {
+        readonly string _connectionString;
+
+        readonly string _tableName;
+
+        readonly InvariantExtractor _invariantExtractor = new InvariantExtractor();
+
+        readonly StringMap<TKey> _keyMap;
+
+        readonly IValidator<TKey, TValue> _validator;
+
+        public AzureTableStore(
+            string connectionString,
+            string tableName,
+            string keyMap,
+            [Optional]IValidator<TKey, TValue> validator = null)
+        {
+            _connectionString = connectionString;
+
+            _tableName = tableName;
+
+            _keyMap = keyMap;
+
+            _validator = validator;
+        }
+
+        public IDataStoreContext<TKey> Context => throw new NotImplementedException();
+
+        public IStringMap<TKey> KeyMap => _keyMap;
+        
+        public async Task<bool> Create(TKey key, TValue value)
+        {
+            //TODO: At present, we can only use objects that have a default constructor and properties that have a setter.
+            //This limitation is due to our usage of the TableEntityAdapter<T> class. A custom implementation for reading
+            //and writing our TableEntity objects should allow us to lift this limitation in the future.
+            /*******
+            Strategy for building objects to send to Table Storage:
+            1. Identify all properties (with public getters?).
+            2. For each property, write its name/value as an entry in the dictionary.
+            3. Any complex properties should be serialized recursively.
+            4. Write the object.
+
+            Partition Key: typeof(TValue).Name;
+            Row Key: KeyMap.Map(key); - with regex replacement of invalid characters
+            ********/
+
+            /*******
+            Strategy for reconstructing objects from Table Storage:
+            1. Look for constructors. If a default constructor exists, use it.
+            2. If there is no default constructor, look for the constructor with the most arguments.
+            2b. Alternatively, try to find the best one with the known properties.
+            3. Convert all of the properties into the proper name format (use a regex for matching).
+            4. Create an instance of the object with the chosen constructor and properties.
+            5. For any properties with public setters that are not in the constructor, set them.
+            6. Return the object.
+            ********/
+
+            if (await Exists(key)) 
+            {
+                return false;
+            }
+
+            await ValidatePut(key, value);
+
+            var tableEntity = ConvertToTableEntity(key, value);
+
+            return await ExecuteTableOperationAsync(
+                TableOperation.Insert(tableEntity), 
+                HttpStatusCode.NoContent);
+        }
+
+        public async Task<bool> Delete(TKey key)
+        {
+            var existingTableEntity = await GetTableEntity(key);
+
+            if (existingTableEntity == null) 
+            {
+                return false;
+            }
+
+            await ValidateDelete(key);
+
+            return await ExecuteTableOperationAsync(
+                TableOperation.Delete(existingTableEntity), 
+                HttpStatusCode.NoContent);
+        }
+
+        public async Task<bool> Exists(TKey key)
+        {
+            return await Get(key) != null;
+        }
+
+        public async Task<TValue> Get(TKey key)
+        {
+            var tableEntity = await GetTableEntity(key);
+
+            return tableEntity == null
+                ? default(TValue)
+                : tableEntity.OriginalEntity;
+        }
+
+        public async Task<IEnumerable<TKey>> ListKeys(Expression<Func<TKey, bool>> predicate = null)
+        {
+            return (await ListTableEntities(predicate))
+                .Select(tableEntity => _keyMap.Map(tableEntity.RowKey));
+        }
+
+        public async Task<IEnumerable<TValue>> ListValues(Expression<Func<TKey, bool>> predicate = null)
+        {
+            return (await ListTableEntities(predicate))
+                .Select(tableEntity => tableEntity.OriginalEntity);
+        }
+
+        public async Task<IEnumerable<KeyValuePair<TKey, TValue>>> ListKeyValues(
+            Expression<Func<TKey, bool>> predicate = null)
+        {
+            return (await ListTableEntities(predicate))
+                .ToDictionary(
+                    tableEntity => _keyMap.Map(tableEntity.RowKey),
+                    tableEntity => tableEntity.OriginalEntity);
+        }
+
+        public async Task<bool> Update(TKey key, TValue value)
+        {
+            var existingTableEntity = await GetTableEntity(key);
+            if (existingTableEntity == null) 
+            {
+                return false;
+            }
+
+            await ValidatePut(key, value);
+
+            var updatedTableEntity = ConvertToTableEntity(key, value, existingTableEntity.ETag);
+
+            return await ExecuteTableOperationAsync(
+                TableOperation.Replace(updatedTableEntity), 
+                HttpStatusCode.NoContent);
+        }
+
+        public async Task<bool> Upsert(TKey key, TValue value)
+        {
+            await ValidatePut(key, value);
+
+            var tableEntity = ConvertToTableEntity(key, value);
+
+            return await ExecuteTableOperationAsync(
+                TableOperation.InsertOrReplace(tableEntity), 
+                HttpStatusCode.NoContent);
+        }
+
+        public async Task<bool> Upsert(TKey key, Func<TValue, TValue> mutator)
+        {
+            var existing = await Get(key).ConfigureAwait(false);
+
+            if (existing == null) 
+            {
+                return false;
+            }
+
+            var mutation = mutator(existing);
+
+            await ValidatePut(key, mutation);
+
+            var tableEntity = ConvertToTableEntity(key, mutation);
+
+            return await ExecuteTableOperationAsync(
+                TableOperation.Replace(tableEntity), 
+                HttpStatusCode.NoContent);
+        }
+
+        public IQuerySession<TKey, TValue> StartQuery()
+        {
+            throw new NotSupportedException();
+        }
+
+        CloudTable GetTable() 
+        {
+            var storageAccount = CloudStorageAccount.Parse(_connectionString);
+            var tableClient = storageAccount.CreateCloudTableClient();
+            return tableClient.GetTableReference(_tableName);
+        }
+
+        string GetPartitionKey()
+        {
+            return typeof(TValue).Name;
+        }
+
+        string GetRowKey(TKey key)
+        {
+            return RemoveInvalidCharacters(_keyMap.Map(key));
+        }
+
+        TableEntityAdapter<TValue> ConvertToTableEntity(
+            TKey key,
+            TValue value,
+            string eTag = null) 
+        {
+            return new TableEntityAdapter<TValue>(
+                value,
+                GetPartitionKey(),
+                GetRowKey(key)
+            )
+            {
+                ETag = eTag
+            };
+        }
+
+        async Task<TableEntityAdapter<TValue>> GetTableEntity(TKey key)
+        {
+            var retrieveOperation = TableOperation.Retrieve<TableEntityAdapter<TValue>>(
+                GetPartitionKey(),
+                GetRowKey(key));
+
+            var result = await GetTable().ExecuteAsync(retrieveOperation).ConfigureAwait(false);
+
+            return result?.Result as TableEntityAdapter<TValue>;
+        }
+
+        async Task<IEnumerable<TableEntityAdapter<TValue>>> ListTableEntities(
+            Expression<Func<TKey, bool>> predicate = null)
+        {
+            var keyStringPrefix = ResolveKeyStringPrefix(predicate);
+
+            var query = new TableQuery<TableEntityAdapter<TValue>>()
+                .Where(TableQuery.GenerateFilterCondition("PartitionKey", QueryComparisons.Equal, GetPartitionKey()));
+
+            var table = GetTable();
+            var continuationToken = default(TableContinuationToken);
+            var results = new List<TableEntityAdapter<TValue>>();
+
+            do
+            {
+                var tableQueryResult = await table.ExecuteQuerySegmentedAsync(query, continuationToken).ConfigureAwait(false);
+
+                continuationToken = tableQueryResult.ContinuationToken;
+
+                results.AddRange(tableQueryResult.Results);
+            } 
+            while(continuationToken != null);
+
+            return results;
+        }
+
+        async Task<bool> ExecuteTableOperationAsync(TableOperation operation, HttpStatusCode expectedStatusCode) 
+        {
+            var result = await GetTable().ExecuteAsync(operation).ConfigureAwait(false);
+
+            return result?.HttpStatusCode == (int)expectedStatusCode;
+        }
+
+        //TODO: Improve this with a regex that covers more invalid characters. 
+        string RemoveInvalidCharacters(string tableEntry) 
+        {
+            return tableEntry.Replace("/", "_");
+        }
+
+        //TODO: This method (and a couple below it) were lifted from FileStoreDataStore. Consolidate this code for reuse.
+        string ResolveKeyStringPrefix(Expression<Func<TKey, bool>> selector)
+        {
+            var memberValues = EmptyReadOnlyDictionary<string, object>.Instance as
+                IReadOnlyDictionary<string, object>;
+
+            if (selector != null)
+            {
+                memberValues = _invariantExtractor.ExtractInvariantDictionary(
+                    selector,
+                    out Expression<Func<TKey, bool>> invariantExpression);
+            }
+
+            return EvaluateKeyMap(memberValues, true);
+        }
+
+        string EvaluateKeyMap(
+            IReadOnlyDictionary<string, object> memberValues,
+            bool allowPartialMap = false)
+        {
+            try
+            {
+                return RemoveInvalidCharacters(_keyMap.Map(memberValues, allowPartialMap));
+            }
+            catch (ArgumentNullException ex)
+            {
+                throw new IncompleteKeyException(
+                    $"Key map for {typeof(TValue).Name} could not be evaluated " +
+                    $"because key {typeof(TKey).Name} was missing a value for {ex.ParamName}.");
+            }
+        }
+
+        async Task ValidatePut(TKey key, TValue value)
+        {
+            if(_validator != null)
+            {
+                var validationErrors = await _validator.ValidatePut(key, value, _keyMap);
+
+                if (validationErrors?.Any() ?? false)
+                {
+                    throw new ValidationException(validationErrors);
+                }
+            }
+        }
+
+        async Task ValidateDelete(TKey key)
+        {
+            if(_validator != null)
+            {
+                var validationErrors = await _validator.ValidateDelete(key, _keyMap);
+
+                if (validationErrors?.Any() ?? false)
+                {
+                    throw new ValidationException(validationErrors);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR includes an integration to Azure Tables along with an integration test to ensure that all supported methods are working correctly. At present, it's only been tested in .NET Core against Azure Table Storage, but it should theoretically work in .NET Framework and for Cosmos DB Tables as well.

I mentioned this in a comment within the AzureTableStore class, but there's currently a requirement that all classes stored with this implementation have a default constructor and that all properties being stored have a setter (the setter can be private, but it must be explicitly added). I plan to remove this limitation in a future pull request.