### PR TITLE
Bump AzureTables and DocumentDB package versions.

### DIFF
--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/DocumentDbDataStoreTests.cs
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/DocumentDbDataStoreTests.cs
@@ -80,6 +80,8 @@ namespace Halforbit.DataStores.DocumentStores.DocumentDb.Tests
 
                 Assert.Equal(2, result.Count);
             }
+
+            ClearDataStore(dataStore);
         }
     }
 

--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
@@ -1,14 +1,14 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp2.0;net462;net47</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Halforbit.Facets" Version="1.0.40" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.3.0" />

--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Halforbit.DataStores" Version="1.5.3" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="1.6.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
   </ItemGroup>
 
 </Project>

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/Halforbit.DataStores.TableStores.AzureTables.Tests.csproj
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables.Tests/Halforbit.DataStores.TableStores.AzureTables.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.0;net462;net47</TargetFrameworks>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Halforbit.DataStores.TableStores.AzureTables.csproj
+++ b/TableStores/AzureTables/Halforbit.DataStores.TableStores.AzureTables/Halforbit.DataStores.TableStores.AzureTables.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Halforbit.DataStores" Version="1.5.3" />
-    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="0.10.0-preview" />
+    <PackageReference Include="Microsoft.Azure.Cosmos.Table" Version="1.0.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Update Microsoft package for AzureTables to use a stable version, rather than the prerelease which was originally used.
Update to the latest version of Microsoft.Azure.DocumentDB.Core to get all projects on the latest major version (2.x) and fix a runtime mismatch.