### PR TITLE
Bump Microsoft.Azure.DocumentDB.Core Package Version

### DIFF
--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Halforbit.Facets" Version="1.0.40" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.5.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.3.0" />

--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.csproj
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Halforbit.DataStores" Version="1.5.3" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.5.1" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
The current version of Microsoft.Azure.DocumentDB.Core (2.4.0) is no longer shipped by Microsoft, and can't be easily installed by legacy projects that require it. Bumping to the latest stable version will be sufficient to address this.