### PR TITLE
Bump DocumentDB.Core Package Version to Fix Runtime Error

### DIFF
--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.Tests/Halforbit.DataStores.DocumentStores.DocumentDb.Tests.csproj
@@ -8,7 +8,6 @@
 
   <ItemGroup>
     <PackageReference Include="Halforbit.Facets" Version="1.0.40" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0-preview-20170628-02" />
     <PackageReference Include="xunit" Version="2.3.0" />

--- a/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.csproj
+++ b/DocumentStores/DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb/Halforbit.DataStores.DocumentStores.DocumentDb.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
@@ -25,7 +25,7 @@
 
   <ItemGroup>
     <PackageReference Include="Halforbit.DataStores" Version="1.5.3" />
-    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Azure.DocumentDB.Core" Version="2.6.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
When version 2.5.1 of DocumentDB.Core is used alongside another Azure package (e.g. Cosmos.Table), a runtime exception is thrown.
Bump DocumentDB.Core to a version >=2.6.0 to prevent this from happening.