### PR TITLE
Bump CosmosDB package to latest stable version

### DIFF
--- a/DocumentStores/CosmosDb/Halforbit.DataStores.DocumentStores.CosmosDb/Halforbit.DataStores.DocumentStores.CosmosDb.csproj
+++ b/DocumentStores/CosmosDb/Halforbit.DataStores.DocumentStores.CosmosDb/Halforbit.DataStores.DocumentStores.CosmosDb.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.4.1" />
+    <PackageReference Include="Microsoft.Azure.Cosmos" Version="3.6.0" />
     <PackageReference Include="Polly" Version="5.8.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Version bump fixes null ref when accessing legacy fixed collections (with no partition key).