### PR TITLE
Migrate to Azure Blobs v12.6

### DIFF
--- a/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.csproj
+++ b/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.csproj
@@ -20,6 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
     <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 

--- a/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.csproj
+++ b/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.csproj
@@ -21,7 +21,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.6.0" />
-    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Data Stores blob access is using a long-deprecated version of the blob access packages, `WindowsAzure.Storage 8.5.0`. Here we update to the latest stable version of the latest library, `Azure.Storage.Blobs 12.6.0`. There are several substantial refactorings of the API that we adapt to here, but nothing that looks untoward.

docs re. blobs v12:
https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-dotnet