### PR TITLE
Improve shardId not found message

### DIFF
--- a/Halforbit.DataStores/Implementation/ShardedDataStore.cs
+++ b/Halforbit.DataStores/Implementation/ShardedDataStore.cs
@@ -185,7 +185,7 @@ namespace Halforbit.DataStores
                 return shardStore;
             }
 
-            throw new ArgumentException($"A shard with id '{_keyToShardId}' is not configured.");
+            throw new ArgumentException($"A shard with id '{shardId}' is not configured.");
         }
 
         IDataStore<TKey, TValue> ResolveStore(TKey key) => ResolveStore(_keyToShardId(key));


### PR DESCRIPTION
With this, we'll show the shardId value in the error message instead of `Func<....blahblah`