### PR TITLE
Update to Azure.Storage.Blobs 12.16.0

### DIFF
--- a/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.csproj
+++ b/FileStores/BlobStorage/Halforbit.DataStores.FileStores.BlobStorage/Halforbit.DataStores.FileStores.BlobStorage.csproj
@@ -20,7 +20,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="8.5.0" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.16.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/release-notes.md
+++ b/release-notes.md
@@ -2,6 +2,12 @@
 
 ## Release Notes
 
+### 2023-05-21
+
+#### 3.14.0
+
+- Change blob storage integration to use `Azure.Storage.Blobs` 12.16.0.
+
 ### 2023-01-03
 
 #### 3.13.16


### PR DESCRIPTION
Data Stores blob access is using a long-deprecated version of the blob access packages, `WindowsAzure.Storage` 8.5.0. Here we update to the latest stable version of the latest library, `Azure.Storage.Blobs` 12.16.0. There are several substantial refactorings of the API that we adapt to here, but nothing that looks untoward.

docs re. blobs v12:
https://docs.microsoft.com/en-us/azure/storage/blobs/storage-quickstart-blobs-dotnet